### PR TITLE
Do not attempt to add empty response to history.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -91,7 +91,7 @@ LLM.prototype.send = async function (opts = {}) {
         return this.stream_response(response);
     }
 
-    this.assistant(response);
+    if (response) this.assistant(response);
     return response;
 }
 
@@ -102,7 +102,7 @@ LLM.prototype.stream_response = async function* (response) {
         yield chunk;
     }
 
-    this.assistant(buffer);
+    if (buffer) this.assistant(buffer);
 }
 
 LLM.prototype.chat = async function (content, options = null) {


### PR DESCRIPTION
Ollama will sometimes return:

```json
{"model":"deepseek-coder:6.7b-base-q8_0","created_at":"2024-03-14T23:06:20.168252895Z","message":{"role":"assistant","content":""},"done":true,"total_duration":23361002,"load_duration":603619,"prompt_eval_count":6,"prompt_eval_duration":14703000,"eval_count":1,"eval_duration":6000}
```

This is not illegal, but would lead to this error in LLM.js:

```text
2024-03-14T23:06:20+0000 [error] Error: No content provided
    at LLM.history (file:///workspaces/node/node_modules/@themaximalist/llm.js/src/index.js:126:25)
    at LLM.assistant (file:///workspaces/node/node_modules/@themaximalist/llm.js/src/index.js:122:10)
    at LLM.stream_response (file:///workspaces/node/node_modules/@themaximalist/llm.js/src/index.js:105:10)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async file:///workspaces/node/routes/ai/index.js:39:34
```

I added code to avoid attempting to add "" to history, when "" was the response from the LLM.

