### PR TITLE
Add an abort() method in LLM

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,10 @@ const response = await llm.chat("hello");
 console.log(response); // hi
 ```
 
+#### `abort()`
+
+Aborts an ongoing stream.  
+
 #### `user(input=<string>)`
 
 Adds a message from `user` to `Message History`.

--- a/src/anthropic.js
+++ b/src/anthropic.js
@@ -56,6 +56,11 @@ export default async function Anthropic(messages, options = {}) {
 
     log(`sending with options ${JSON.stringify(anthropicOptions)}`);
 
+    const signal = new AbortController();
+    if (options.eventEmitter) {
+        options.eventEmitter.on('abort', () => signal.abort());
+    }
+
     const response = await fetch(options.endpoint || ENDPOINT, {
         method: "POST",
         headers: {
@@ -64,7 +69,7 @@ export default async function Anthropic(messages, options = {}) {
             "x-api-key": apiKey,
         },
         body: JSON.stringify(anthropicOptions)
-    });
+    }, { signal: signal.signal } );
 
     if (!response.ok) { throw new Error(`HTTP error! status: ${response.status}`) }
 

--- a/src/google.js
+++ b/src/google.js
@@ -29,13 +29,18 @@ export default async function Google(messages, options = {}) {
 
     log(`sending to Google endpoint with body ${JSON.stringify(body)}`);
 
+    const signal = new AbortController();
+    if (options.eventEmitter) {
+        options.eventEmitter.on('abort', () => signal.abort());
+    }
+
     const response = await fetch(endpoint, {
         method: "POST",
         headers: {
             "Content-Type": "application/json",
         },
         body: JSON.stringify(body)
-    });
+    }, { signal: signal.signal });
 
     if (!response.ok) { throw new Error(`HTTP error! status: ${response.status}`) }
 

--- a/src/llamafile.js
+++ b/src/llamafile.js
@@ -29,11 +29,16 @@ export default async function LlamaFile(messages, options = {}) {
 
     log(`sending to ${ENDPOINT} with body ${JSON.stringify(body)}`);
 
+    const signal = new AbortController();
+    if (options.eventEmitter) {
+        options.eventEmitter.on('abort', () => signal.abort());
+    }
+
     const response = await fetch(options.endpoint || ENDPOINT, {
         method: "POST",
         headers: { "Content-Type": "application/json", "Authorization": "Bearer no-key" },
         body: JSON.stringify(body)
-    });
+    }, { signal: signal.signal });
 
     if (!response.ok) { throw new Error(`HTTP error! status: ${response.status}`) }
 

--- a/src/mistral.js
+++ b/src/mistral.js
@@ -29,6 +29,11 @@ export default async function Mistral(messages, options = {}) {
 
     log(`sending to ${ENDPOINT} with body ${JSON.stringify(body)}`);
 
+    const signal = new AbortController();
+    if (options.eventEmitter) {
+        options.eventEmitter.on('abort', () => signal.abort());
+    }
+
     const response = await fetch(options.endpoint || ENDPOINT, {
         method: "POST",
         headers: {
@@ -37,7 +42,7 @@ export default async function Mistral(messages, options = {}) {
             "Authorization": `Bearer ${apiKey}`
         },
         body: JSON.stringify(body)
-    });
+    }, { signal: signal.signal });
 
     if (!response.ok) { throw new Error(`HTTP error! status: ${response.status}`) }
 

--- a/src/modeldeployer.js
+++ b/src/modeldeployer.js
@@ -26,11 +26,17 @@ export default async function ModelDeployer(messages, options = {}) {
 
     const endpoint = options.endpoint || ENDPOINT;
     log(`sending to ${endpoint} with body ${JSON.stringify(body)}`);
+
+    const signal = new AbortController();
+    if (options.eventEmitter) {
+        options.eventEmitter.on('abort', () => signal.abort());
+    }
+
     const response = await fetch(endpoint, {
         method: "POST",
         headers: { "Content-Type": "application/json", "x-api-key": apikey },
         body: JSON.stringify(body)
-    });
+    }, { signal: signal.signal });
 
     if (!response.ok) { throw new Error(`HTTP error! status: ${response.status}`) }
     if (options.stream) { return stream_response(response) }

--- a/src/ollama.js
+++ b/src/ollama.js
@@ -45,6 +45,9 @@ export default async function Ollama(messages, options = {}) {
     const endpoint = options.endpoint || ENDPOINT;
 
     const ollama = new OllamaClient({ host: endpoint });
+    if (options.eventEmitter) {
+        options.eventEmitter.on('abort', () => ollama.abort());
+    }
     let ollamaOptions = {};
     for (const key of OllamaOptions) {
         if (typeof options[key] !== "undefined") {

--- a/test/test_ollama.js
+++ b/test/test_ollama.js
@@ -68,4 +68,20 @@ describe("ollama", function () {
         const response = await llm.chat("the color of the sky is");
         assert(response.toLowerCase().indexOf("yellow") !== -1, response);
     });
+
+    it('can abort', async function () {
+        const llm = new LLM([], { stream: true, temperature: 0, model });
+
+        let response = await llm.chat("tell me a long story about hair");
+        let aborted = false;
+        setTimeout(() => llm.abort(), 700);
+        try {
+          for await (const content of response) {
+          }
+        } catch(err) {
+          aborted = true;
+          assert(err.name === "AbortError");
+        }
+        assert(aborted);
+    });
 });

--- a/test/test_openai.js
+++ b/test/test_openai.js
@@ -159,4 +159,21 @@ describe("openai", function () {
 
         assert(colors.length > 0);
     });
+
+    it('can abort', async function () {
+      const llm = new LLM([], { stream: true, temperature: 0, model });
+
+      let response = await llm.chat("tell me a long story about hair");
+      let aborted = false;
+      let shouldAbort = false;
+      setTimeout(() => {shouldAbort = true}, 700);
+      try {
+        for await (const content of response) {
+          if (shouldAbort) break; // the proper way to abort with OpenAI
+        }
+      } catch(err) {
+        aborted = true;
+      }
+      assert(!aborted); // OpenAI does not error when aborted
+  });
 });


### PR DESCRIPTION
Copilots like Cody will invoke an LLM for auto completion and abort the connection when they are satisfied with what they've received so far, even though the LLM continues to generate tokens.  For Ollama, the ollama client has an abort() method that will stop the token generation.  I added an EventEmitter to LLM and an abort() method that emits an "abort" event.  This emitter is passed via options{} to the services.  The fetch-based services add a "signal" to fetch, and use the event emitter to tigger it.  Ollama calls its abort() method.  OpenAI does not appear to need a mechanism like this; it is enough to break out of the streaming await-loop.  I added a test case for Ollama and OpenAI.  

As an aside, it seems there is a problem with LLM.parsers.  The test/test_parser.js fails, as does any other testcase that attempts to deference LLM.parsers.  Not sure what this is, so I am not touching it.